### PR TITLE
Handle empty datapoints array by not displaying the series

### DIFF
--- a/src/status_ctrl.js
+++ b/src/status_ctrl.js
@@ -248,6 +248,10 @@ export class StatusPluginCtrl extends MetricsPanelCtrl {
 				return;
 			}
 
+			if (s.datapoints.length === 0) {
+				return;
+			}
+
 			s.alias = target.alias;
 			s.url = target.url;
 			s.isDisplayValue = true;


### PR DESCRIPTION
If a data source has no datapoints don't display the item in the panel.  This will resolve #111.