### PR TITLE
fix metric decimals with "0" value

### DIFF
--- a/src/editor.html
+++ b/src/editor.html
@@ -270,7 +270,7 @@
 						</info-popover>
 					</span>
 					<input type="number" name="decimals" ng-model="measurement.decimals"
-						   ng-init="measurement.decimals = (measurement.decimals ? measurement.decimals : 2)"
+						   ng-init="measurement.decimals = (measurement.decimals!=undefined ? measurement.decimals : 2)"
 						   placeholder="auto" class="gf-form-input max-width-14" ng-change="ctrl.onRender()" />
 				</div>
 			</div>


### PR DESCRIPTION
When editing a panel and in the options define a number threshold for a metric, it is possible to define the decimals to be displayed as a number. That works fine unless "0" is inserted as value, in that case when re-opening the panel in edit mode it will be displayed as the default value "2" and the previously configured value is lost.
Reason is that "0" in javascript is falsy and therefore treats the value as unset and uses the default instead.
Tested with my scenario and should also fix the issue as described in https://github.com/Vonage/Grafana_Status_panel/issues/98
