### PR TITLE
Allow templated names in the alias field.  Fixes #91.

### DIFF
--- a/src/status_ctrl.js
+++ b/src/status_ctrl.js
@@ -245,14 +245,14 @@ export class StatusPluginCtrl extends MetricsPanelCtrl {
 			}
 
 			let target = _.find(targets, (target) => {
-				return target.alias == s.alias || target.target == s.alias;
+				const templatizedName = this.filter('interpolateTemplateVars')(target.alias, this.$scope);
+				return target.alias == s.alias || target.target == s.alias || target.alias == templatizedName;
 			});
 
 			if (!target) {
 				return;
 			}
 
-			s.alias = target.alias;
 			s.url = target.url;
 			s.isDisplayValue = true;
 			s.displayType = target.displayType;


### PR DESCRIPTION
Using $tag_ syntax failed when adding it inside the Alias By clause of a query.  This PR checks the templated names as well to ensure we can use multiple queries and display them in a meaningful way.

Fixes #91 