### PR TITLE
Fix broken links in grafana 6.3.x

### DIFF
--- a/src/status_ctrl.js
+++ b/src/status_ctrl.js
@@ -534,17 +534,7 @@ export class StatusPluginCtrl extends MetricsPanelCtrl {
 	parseUri() {
 		if (this.panel.links && this.panel.links.length > 0) {
 			let link = this.panel.links[0];
-
-			if (link.type == "absolute") {
-				this.uri = link.url;
-			} else {
-				this.uri = 'dashboard/' + link.dashUri;
-			}
-
-			if (link.params) {
-				this.uri +=  "?" + link.params;
-			}
-
+			this.uri = link.url;
 			this.targetBlank = link.targetBlank;
 		} else {
 			this.uri = undefined;


### PR DESCRIPTION
When you define in a link to open to somewhere, type is not provided
anymore in the link parameters so it defaults to undefined all the time,
so it opens a non-existing dashboard.

The only parameters provided together with the panel are:
- targetBlank
- title
- url

Defaulting the this.uri to link.url fixes the issue

Fixes #133 for at least grafana >= 6.3.x (haven't tried for other versions)