### PR TITLE
fix(status_ctrl): status-panel stop working after upgrade Grafana to v6.7.x

### DIFF
--- a/dist/status_ctrl.js
+++ b/dist/status_ctrl.js
@@ -699,7 +699,7 @@ System.register(["app/plugins/sdk", "lodash", "app/core/time_series2", "app/core
 				}, {
 					key: "link",
 					value: function link(scope, elem, attrs, ctrl) {
-						this.$panelContainer = elem.find('.panel-container');
+						this.$panelContainer = elem;
 						this.$panelContainer.addClass("st-card");
 						this.$panelContoller = ctrl;
 					}

--- a/src/status_ctrl.js
+++ b/src/status_ctrl.js
@@ -624,7 +624,7 @@ export class StatusPluginCtrl extends MetricsPanelCtrl {
 	}
 
 	link(scope, elem, attrs, ctrl) {
-		this.$panelContainer = elem.find('.panel-container');
+		this.$panelContainer = elem;
 		this.$panelContainer.addClass("st-card");
 		this.$panelContoller = ctrl;
 	}


### PR DESCRIPTION
fix(status_ctrl): status-panel stop working after upgrade Grafana to v6.7.x. Solution thanks to @sgolubevCY. Resolve issue #159